### PR TITLE
Improve the composer caching on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files


### PR DESCRIPTION
Persisting the cache of downloading archives is good. But persisting the cache of repository metadata downloads is not a PAckagist metadata are likely to be updated between each build, which would require Travis to update its cache all the time.
