### PR TITLE
If the successful response is json why not the failure response?

### DIFF
--- a/src/Security/TokenAuthenticator.php
+++ b/src/Security/TokenAuthenticator.php
@@ -13,8 +13,8 @@
 namespace Antenna\Security;
 
 use Antenna\Coder;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -99,7 +99,10 @@ class TokenAuthenticator implements SimplePreAuthenticatorInterface, Authenticat
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        return new Response($exception->getMessage(), 401, [
+        return new JsonResponse([
+            'code' => 401,
+            'message' => $exception->getMessage(),
+        ], 401, [
             'WWW-Authenticate' => 'Bearer',
         ]);
     }

--- a/src/Security/UsernamePasswordAuthenticator.php
+++ b/src/Security/UsernamePasswordAuthenticator.php
@@ -16,7 +16,6 @@ use Antenna\Coder;
 use Antenna\WebToken;
 use Antenna\ClaimsAwareInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -116,7 +115,10 @@ class UsernamePasswordAuthenticator implements
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        return new Response($exception->getMessage(), 401);
+        return new JsonResponse([
+            'code' => 401,
+            'message' => $exception->getMessage(),
+        ], 401);
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token)

--- a/tests/Security/TokenAuthenticatorTest.php
+++ b/tests/Security/TokenAuthenticatorTest.php
@@ -43,9 +43,11 @@ class TokenAuthenticatorTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
 
         $response = $this->authenticator->onAuthenticationFailure($request, $exception);
+        $decoded = json_decode($response->getContent(), true);
 
         $this->assertEquals(401, $response->getStatusCode());
-        $this->assertEquals('My Custom Message', $response->getContent());
+        $this->assertEquals(401, $decoded['code']);
+        $this->assertEquals($exception->getMessage(), $decoded['message']);
     }
 
     public function testSupportsToken()

--- a/tests/Security/UsernamePasswordAuthenticatorTest.php
+++ b/tests/Security/UsernamePasswordAuthenticatorTest.php
@@ -15,10 +15,12 @@ namespace Antenna\Tests\Security;
 use Antenna\Coder;
 use Antenna\Security\UsernamePasswordAuthenticator;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Encoder\EncoderFactory;
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserChecker;
@@ -109,6 +111,17 @@ class UsernamePasswordAuthenticatorTest extends \PHPUnit_Framework_TestCase
         $token = new UsernamePasswordToken('my_username', 'my_invalid_password', 'my_provider');
 
         $this->authenticator->authenticateToken($token, $this->userProvider, 'my_provider');
+    }
+
+    public function testAuthenticationFailedHandler()
+    {
+        $exception = new BadCredentialsException('The presented password is invalid.');
+
+        $response = $this->authenticator->onAuthenticationFailure(Request::create('/'), $exception);
+        $decoded = json_decode($response->getContent(), true);
+
+        $this->assertEquals(401, $decoded['code']);
+        $this->assertEquals($exception->getMessage(), $decoded['message']);
     }
 
     public function testSupportsToken()


### PR DESCRIPTION
I've changed the returned response on failing authentication to json responses so you always get a response in the same format. I used the same exception format as the FOSRestBundle uses by default. 
